### PR TITLE
Request to Merge

### DIFF
--- a/integration/avif/src/main/java/com/bumptech/glide/integration/avif/AvifGlideModule.java
+++ b/integration/avif/src/main/java/com/bumptech/glide/integration/avif/AvifGlideModule.java
@@ -2,10 +2,12 @@ package com.bumptech.glide.integration.avif;
 
 import android.content.Context;
 import android.graphics.Bitmap;
+import android.graphics.drawable.BitmapDrawable;
 import androidx.annotation.NonNull;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.Registry;
 import com.bumptech.glide.annotation.GlideModule;
+import com.bumptech.glide.load.resource.bitmap.BitmapDrawableDecoder;
 import com.bumptech.glide.module.LibraryGlideModule;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
@@ -21,10 +23,21 @@ public final class AvifGlideModule extends LibraryGlideModule {
     // the integration will be preferred for Avif images.
     AvifByteBufferBitmapDecoder byteBufferBitmapDecoder =
         new AvifByteBufferBitmapDecoder(glide.getBitmapPool());
-    registry.prepend(ByteBuffer.class, Bitmap.class, byteBufferBitmapDecoder);
+    registry.prepend(
+        Registry.BUCKET_BITMAP, ByteBuffer.class, Bitmap.class, byteBufferBitmapDecoder);
+    registry.prepend(
+        Registry.BUCKET_BITMAP_DRAWABLE,
+        ByteBuffer.class,
+        BitmapDrawable.class,
+        new BitmapDrawableDecoder<>(context.getResources(), byteBufferBitmapDecoder));
     AvifStreamBitmapDecoder streamBitmapDecoder =
         new AvifStreamBitmapDecoder(
             registry.getImageHeaderParsers(), byteBufferBitmapDecoder, glide.getArrayPool());
-    registry.prepend(InputStream.class, Bitmap.class, streamBitmapDecoder);
+    registry.prepend(Registry.BUCKET_BITMAP, InputStream.class, Bitmap.class, streamBitmapDecoder);
+    registry.prepend(
+        Registry.BUCKET_BITMAP_DRAWABLE,
+        InputStream.class,
+        BitmapDrawable.class,
+        new BitmapDrawableDecoder<>(context.getResources(), streamBitmapDecoder));
   }
 }


### PR DESCRIPTION
### **User description**
> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.


___

### **PR Type**
enhancement, bug_fix


___

### **Description**
- Updated `AvifGlideModule` to use specific registry buckets (`BUCKET_BITMAP` and `BUCKET_BITMAP_DRAWABLE`) instead of the default `prepend_all` bucket.
- Added `BitmapDrawableDecoder` to handle decoding into `BitmapDrawable`, preventing incorrect interactions with the Downsampler.
- Ensured that Avif decoders are preferred for Avif images, addressing issue #5051 related to GIF animations.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AvifGlideModule.java</strong><dd><code>Update AvifGlideModule to use correct registry buckets</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integration/avif/src/main/java/com/bumptech/glide/integration/avif/AvifGlideModule.java

<li>Added <code>BitmapDrawableDecoder</code> for decoding into <code>BitmapDrawable</code>.<br> <li> Changed registry bucket from <code>prepend_all</code> to <code>BUCKET_BITMAP</code> and <br><code>BUCKET_BITMAP_DRAWABLE</code>.<br> <li> Ensured Avif decoders are preferred for Avif images.<br> <li> Addressed issue with GIF animations by adjusting decoder <br>configuration.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/glide/pull/2/files#diff-28fb28b065a15ab070ae0c590953c6ea3911a30b5e94688dda35a22ef36308ac">+15/-2</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information